### PR TITLE
Scale image before loading

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,15 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="96e8e18d-d5b4-497a-9dfc-d2bdff51b7c3" name="Changes" comment="Add animations">
+    <list default="true" id="646f9bf0-d115-48e2-a25e-4e918920ac7e" name=" scale image when loading" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/rpgkit/Tile.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/rpgkit/Tile.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/rpgkit/TileSet.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/rpgkit/TileSet.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/rpgkit/drawable/entity/Player.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/rpgkit/drawable/entity/Player.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/rpgkit/drawable/entity/item/Item.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/rpgkit/drawable/entity/item/Item.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/rpgkit/drawable/ui/item/Item.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/rpgkit/drawable/ui/item/Item.java" afterDir="false" />
+    </list>
+    <list id="96e8e18d-d5b4-497a-9dfc-d2bdff51b7c3" name="Changes" comment="Update .gitignore">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -41,7 +49,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="add-animation" />
+        <entry key="$PROJECT_DIR$" value="production" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -82,6 +90,21 @@
       </collection>
     </option>
   </component>
+  <component name="LineStatusTrackerManager">
+    <file path="$PROJECT_DIR$/.idea/workspace.xml">
+      <ranges>
+        <range start1="6" end1="7" start2="6" end2="13" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="43" end1="44" start2="49" end2="50" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="84" end1="84" start2="90" end2="104" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="118" end1="119" start2="138" end2="139" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="231" end1="232" start2="251" end2="252" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="400" end1="411" start2="420" end2="420" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="427" end1="428" start2="436" end2="448" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+        <range start1="444" end1="445" start2="464" end2="465" changelist="96e8e18d-d5b4-497a-9dfc-d2bdff51b7c3" />
+        <range start1="466" end1="479" start2="486" end2="488" changelist="646f9bf0-d115-48e2-a25e-4e918920ac7e" />
+      </ranges>
+    </file>
+  </component>
   <component name="MacroExpansionManager">
     <option name="directoryName" value="2tvn7nzm" />
   </component>
@@ -116,7 +139,7 @@
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "WebServerToolWindowFactoryState": "false",
     "code.cleanup.on.save": "true",
-    "git-widget-placeholder": "production",
+    "git-widget-placeholder": "scale-image",
     "last_opened_file_path": "/Volumes/Big Drive/Programming Projects/IdeaProjects/RPGkit/src/main/java/rpgkit/ldtk/tile",
     "node.js.detected.package.tslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
@@ -229,7 +252,7 @@
         <item itemvalue="Gradle.RPGkit [dependencies]" />
         <item itemvalue="Gradle.RPGkit [build]" />
         <item itemvalue="Application.Main" />
-        <item itemvalue="Gradle.RPGkit [dependencies]" />
+        <item itemvalue="Java Scratch.Scratch" />
       </list>
     </recent_temporary>
   </component>
@@ -398,17 +421,6 @@
       <option name="project" value="LOCAL" />
       <updated>1692409754696</updated>
     </task>
-    <task active="true" id="LOCAL-00021" summary="auto layer parsing">
-      <branch name="development" repository="$PROJECT_DIR$" original="true" />
-      <branch name="auto-layer-parsing" repository="$PROJECT_DIR$" />
-      <changelist id="67188643-eb50-46a7-85ae-6b3dc91e6364" name=" auto layer parsing" comment="" />
-      <created>1692409992677</created>
-      <option name="number" value="00021" />
-      <option name="presentableId" value="LOCAL-00021" />
-      <option name="project" value="LOCAL" />
-      <updated>1692410010973</updated>
-      <workItem from="1692410011720" duration="3563000" />
-    </task>
     <task id="LOCAL-00022" summary="Update release.yml">
       <option name="closed" value="true" />
       <created>1692457025167</created>
@@ -425,7 +437,18 @@
       <option name="project" value="LOCAL" />
       <updated>1692462345076</updated>
     </task>
-    <option name="localTasksCounter" value="24" />
+    <task active="true" id="LOCAL-00024" summary="scale image when loading">
+      <branch name="production" repository="$PROJECT_DIR$" original="true" />
+      <branch name="scale-image" repository="$PROJECT_DIR$" />
+      <changelist id="646f9bf0-d115-48e2-a25e-4e918920ac7e" name=" scale image when loading" comment="" />
+      <created>1692668468180</created>
+      <option name="number" value="00024" />
+      <option name="presentableId" value="LOCAL-00024" />
+      <option name="project" value="LOCAL" />
+      <updated>1692668470051</updated>
+      <workItem from="1692668470369" duration="516000" />
+    </task>
+    <option name="localTasksCounter" value="25" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -442,7 +465,7 @@
                   <entry key="branch">
                     <value>
                       <list>
-                        <option value="refactor" />
+                        <option value="development" />
                       </list>
                     </value>
                   </entry>
@@ -464,16 +487,16 @@
     <MESSAGE value="Update release.yml" />
     <MESSAGE value=" add animation" />
     <MESSAGE value="Add animations" />
-    <option name="LAST_COMMIT_MESSAGE" value="Add animations" />
+    <MESSAGE value="Update .gitignore" />
+    <option name="LAST_COMMIT_MESSAGE" value="Update .gitignore" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
       <breakpoints>
         <line-breakpoint enabled="true" type="java-line">
-          <condition expression="col == 2" language="JAVA" />
           <url>file://$PROJECT_DIR$/src/main/java/rpgkit/TileSet.java</url>
-          <line>91</line>
-          <option name="timeStamp" value="3" />
+          <line>128</line>
+          <option name="timeStamp" value="4" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/src/main/java/rpgkit/Tile.java
+++ b/src/main/java/rpgkit/Tile.java
@@ -44,9 +44,9 @@ public class Tile implements Animatable {
         this.hitbox.width = (int) (this.tileSet.tileSize * RPGKit.tileScale);
         this.hitbox.height = (int) (this.tileSet.tileSize * RPGKit.tileScale);
 
-        tempImage = Utils.images.scale(tileSet.getFrame(
+        tempImage = tileSet.getFrame(
                 (int) (tileSetPosition[0] / tileSet.tileSize),
-                (int) (tileSetPosition[1] / tileSet.tileSize)), RPGKit.tileScale, RPGKit.tileScale);
+                (int) (tileSetPosition[1] / tileSet.tileSize));
 
         if (tile.getF() == 1) {
             tempImage = Utils.images.flipHorizontal(tempImage);
@@ -121,9 +121,7 @@ public class Tile implements Animatable {
     @Override
     public BufferedImage getNextFrame() {
         long nextFrame = data.getAnimation().getNext();
-        BufferedImage tempImage = Utils.images.scale(tileSet.getFrame((int) nextFrame),
-                                                     RPGKit.tileScale,
-                                                     RPGKit.tileScale);
+        BufferedImage tempImage = tileSet.getFrame((int) nextFrame);
 
         if (tile.getF() == 1) {
             tempImage = Utils.images.flipHorizontal(tempImage);

--- a/src/main/java/rpgkit/TileSet.java
+++ b/src/main/java/rpgkit/TileSet.java
@@ -55,6 +55,7 @@ public class TileSet {
 
     public final long tileSize;
     public final TileCustomMetadata[] metadata;
+    private final RPGKit rpgKit;
 
     /**
      * Constructor for creating a TileSet object.
@@ -63,6 +64,8 @@ public class TileSet {
      * @throws IllegalArgumentException when tileset path not found or invalid
      */
     public TileSet(TilesetDefinition tileSet) {
+        rpgKit = RPGKit.getInstance();
+        
         this.tileSet = tileSet;
         this.uid = tileSet.getUid();
         this.identifier = tileSet.getIdentifier();
@@ -84,15 +87,11 @@ public class TileSet {
     }
 
     public BufferedImage getFrame(int id) {
-//        for (int a = 1; a < 200; a++) {
         int cols = (int) (image.getWidth() / (this.tileSet.getTileGridSize() + this.tileSet.getSpacing()));
 
         int row = ((id - 1) / cols);
         int col = (id) % cols;
-//            System.out.println(col + " " + row);
         return frames[col][row];
-//        }
-//        return null;
     }
 
     /**
@@ -119,16 +118,20 @@ public class TileSet {
     private void cut() {
         long tileCol = image.getWidth() / (this.tileSet.getTileGridSize() + this.tileSet.getSpacing());
         long tileRow = image.getHeight() / (this.tileSet.getTileGridSize() + this.tileSet.getSpacing());
+
         frames = new BufferedImage[(int) tileCol][(int) tileRow];
+
         for (long y = this.tileSet.getPadding(); y < image.getHeight(); y += this.tileSet.getTileGridSize() + this.tileSet.getSpacing()) {
             long framesY = y / (this.tileSet.getTileGridSize() + this.tileSet.getSpacing());
+
             for (long x = this.tileSet.getPadding(); x < image.getWidth(); x += this.tileSet.getTileGridSize() + this.tileSet.getSpacing()) {
                 long framesX = x / (this.tileSet.getTileGridSize() + this.tileSet.getSpacing());
+
                 BufferedImage sprite = image.getSubimage((int) x,
                                                          (int) y,
                                                          (int) this.tileSet.getTileGridSize(),
                                                          (int) this.tileSet.getTileGridSize());
-                frames[(int) framesX][(int) framesY] = sprite;
+                frames[(int) framesX][(int) framesY] = Utils.images.scale(sprite, rpgKit.tileScale, rpgKit.tileScale);
             }
         }
     }

--- a/src/main/java/rpgkit/drawable/entity/Player.java
+++ b/src/main/java/rpgkit/drawable/entity/Player.java
@@ -39,12 +39,10 @@ public class Player extends Entity {
     }
 
     public void loadImage() {
-        images[0] = Utils.images.scale(tileSet.getFrame(0, 0), RPGKit.tileScale, RPGKit.tileScale);
-        images[1] = Utils.images.scale(tileSet.getFrame(1, 0), RPGKit.tileScale, RPGKit.tileScale);
-        images[2] = Utils.images.scale(tileSet.getFrame(2, 0), RPGKit.tileScale, RPGKit.tileScale);
-        images[3] = Utils.images.scale(Utils.images.flipHorizontal(tileSet.getFrame(1, 0)),
-                                       RPGKit.tileScale,
-                                       RPGKit.tileScale);
+        images[0] = tileSet.getFrame(0, 0);
+        images[1] = tileSet.getFrame(1, 0);
+        images[2] = tileSet.getFrame(2, 0);
+        images[3] = Utils.images.flipHorizontal(tileSet.getFrame(1, 0));
     }
 
     @Override

--- a/src/main/java/rpgkit/drawable/entity/item/Item.java
+++ b/src/main/java/rpgkit/drawable/entity/item/Item.java
@@ -21,7 +21,6 @@ public abstract class Item extends Entity {
 
         image = tileSet.getFrame((int) (rectangle.getX() / tileSet.tileSize),
                                  (int) (rectangle.getY() / tileSet.tileSize));
-        image = Utils.images.scale(image, RPGKit.tileScale, RPGKit.tileScale);
     }
 
     public void interact() {

--- a/src/main/java/rpgkit/drawable/ui/item/Item.java
+++ b/src/main/java/rpgkit/drawable/ui/item/Item.java
@@ -2,7 +2,6 @@ package rpgkit.drawable.ui.item;
 
 import rpgkit.RPGKit;
 import rpgkit.drawable.Drawable;
-import rpgkit.util.Utils;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -10,14 +9,13 @@ import java.awt.image.BufferedImage;
 public abstract class Item implements Drawable {
     private final RPGKit RPGKit;
     public long[] screenPosition = null;
-    private BufferedImage image;
+    private final BufferedImage image;
     public int count;
 
     public Item(rpgkit.drawable.entity.item.Item item, int count) {
         this.RPGKit = rpgkit.RPGKit.getInstance();
         this.image = item.tileSet.getFrame((int) (item.rectangle.getX() / item.tileSet.tileSize),
                                            (int) (item.rectangle.getY() / item.tileSet.tileSize));
-        this.image = Utils.images.scale(image, RPGKit.tileScale, RPGKit.tileScale);
         this.count = count;
     }
 


### PR DESCRIPTION
We must scale the images in the tileset before using them. This way, the game can run faster with animations. The previous technique scales the image everytime when loading a new frame of the animation. This can consume a lot of computational power for scenes with a lot of animating objects. Using this new technique, we can pre compute the scaled images when loading the game so that we can use them faster during gameplay.